### PR TITLE
Update logout_request.py

### DIFF
--- a/src/onelogin/saml2/logout_request.py
+++ b/src/onelogin/saml2/logout_request.py
@@ -109,7 +109,7 @@ class OneLogin_Saml2_Logout_Request(object):
                 {
                     'id': self.id,
                     'issue_instant': issue_instant,
-                    'single_logout_url': self.__settings.get_idp_slo_response_url(),
+                    'single_logout_url': self.__settings.get_idp_slo_url(),
                     'entity_id': sp_data['entityId'],
                     'name_id': name_id_obj,
                     'session_index': session_index_str,


### PR DESCRIPTION
In 9fdb11d (which is included in v1.10.0), in addition to logout_response.py, logout_request.py has also been modified. This is incorrect and only the logout_response.py should point to a response URL. Now all _logoutRequest_ and _logoutResponse_ messages are sent to the slo response URL.